### PR TITLE
fix token invalid error

### DIFF
--- a/hh.py
+++ b/hh.py
@@ -1,0 +1,5 @@
+from syrics.api import Spotify
+
+
+sp = Spotify("AQCFDbh4qjdCxAOHzNk-ehVbOUNIMSSs72JxZorIttETE-sycbrfRIYyH6zoNnpXzLIwmyi_kBwi6nIy7T6TavQLMXBySfnVo4v1wxkiPh9BxN1hB5RZ2quXtV2_j8Afla6WlK1Qxgu36qg6U_vF8Z-OX_IP9nyMFApvmgTpQzMIB0oHorA2399HiFvkvwJO9f3K46F6QeRoXbC4a8nrwCgk9i3Q")
+print(sp.get_lyrics("3o9uL1uNPcen0lItb1Hw3m"))

--- a/hh.py
+++ b/hh.py
@@ -1,5 +1,0 @@
-from syrics.api import Spotify
-
-
-sp = Spotify("AQCFDbh4qjdCxAOHzNk-ehVbOUNIMSSs72JxZorIttETE-sycbrfRIYyH6zoNnpXzLIwmyi_kBwi6nIy7T6TavQLMXBySfnVo4v1wxkiPh9BxN1hB5RZ2quXtV2_j8Afla6WlK1Qxgu36qg6U_vF8Z-OX_IP9nyMFApvmgTpQzMIB0oHorA2399HiFvkvwJO9f3K46F6QeRoXbC4a8nrwCgk9i3Q")
-print(sp.get_lyrics("3o9uL1uNPcen0lItb1Hw3m"))

--- a/syrics/api.py
+++ b/syrics/api.py
@@ -50,7 +50,6 @@ class Spotify:
 
     def get_lyrics(self, track_id: str):
         params = 'format=json&market=from_token'
-        print(self.session.headers['authorization'])
         req = self.session.get(f'https://spclient.wg.spotify.com/color-lyrics/v2/track/{track_id}', params=params)
         return req.json() if req.status_code == 200 else None
     

--- a/syrics/totp.py
+++ b/syrics/totp.py
@@ -1,0 +1,35 @@
+import requests
+import hashlib
+import time
+from pyotp import TOTP
+
+class SpotifyTotp:
+
+    def base32_from_bytes(self, data, secret_sauce):
+        t, n, r = 0, 0, ""
+        for byte in data:
+            n = (n << 8) | byte
+            t += 8
+            while t >= 5:
+                r += secret_sauce[(n >> (t - 5)) & 31]
+                t -= 5
+        if t > 0:
+            r += secret_sauce[(n << (5 - t)) & 31]
+        return r
+
+    def clean_buffer(self, hex_str):
+        hex_str = hex_str.replace(" ", "")
+        return bytes.fromhex(hex_str)
+
+    def generate_totp(self):
+        secret_sauce = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        secret_cipher_bytes = [12, 56, 76, 33, 88, 44, 88, 33, 78, 78, 11, 66, 22, 22, 55, 69, 54]
+        secret_cipher_bytes = [(e ^ (t % 33 + 9)) for t, e in enumerate(secret_cipher_bytes)]
+        
+        secret_bytes = bytes.fromhex(''.join(format(b, '02x') for b in bytes(''.join(map(str, secret_cipher_bytes)), 'utf-8')))
+        
+        secret = self.base32_from_bytes(secret_bytes, secret_sauce)
+        
+        totp = TOTP(secret, digits=6, digest=hashlib.sha1, interval=30)
+        return totp.now()
+


### PR DESCRIPTION
Added the latest interface verification for TOTP matching. but sometimes the returned token is not "BA...", usually such token cannot be used, and only verification is done for this problem. The reason may be that the validity period of TOTP in Spotify is too short.